### PR TITLE
Readme.md update - Missing variable COMPOSER_VERSION in example of drush installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,9 @@ RUN apt-get update \
                 --assume-yes \
                 make
 
+# defines Composer version
+ENV COMPOSER_VERSION 1.2.1
+
 # defines Drush version
 ENV DRUSH_VERSION 8.1.3
 
@@ -189,6 +192,9 @@ RUN apt-get update \
                 --no-install-recommends \
                 --assume-yes \
                 make
+
+# defines Composer version
+ENV COMPOSER_VERSION 1.2.1
 
 # defines Drush version
 ENV DRUSH_VERSION 8.1.3


### PR DESCRIPTION
This PR fixes the issue #3